### PR TITLE
Docs and code cleanup

### DIFF
--- a/sdk/rms_sdk/Core/ProtectionPolicy.h
+++ b/sdk/rms_sdk/Core/ProtectionPolicy.h
@@ -9,7 +9,6 @@
 #ifndef _RMS_LIB_PROTECTIONPOLICY_H_
 #define _RMS_LIB_PROTECTIONPOLICY_H_
 
-#include <QMutex>
 #include <chrono>
 #include <CryptoAPI.h>
 #include "../Common/CommonTypes.h"
@@ -63,7 +62,8 @@ public:
     return m_accessStatus;
   }
 
-  bool              AccessCheck(const std::string& right) const;
+  bool AccessCheck(const std::string& right) const;
+
   const std::string GetId() const {
     return m_id;
   }
@@ -100,14 +100,15 @@ public:
     m_requester = requester;
   }
 
-  bool                                              IsIssuedToOwner() const;
-  std::chrono::time_point<std::chrono::system_clock>GetValidityTimeFrom() const {
+  bool IsIssuedToOwner() const;
+
+  std::chrono::time_point<std::chrono::system_clock> GetValidityTimeFrom() const {
     return m_ftValidityTimeFrom;
   }
 
   uint64_t GetValidityTimeDuration() const;
 
-  bool     AllowOfflineAccess() const {
+  bool AllowOfflineAccess() const {
     return m_bAllowOfflineAccess;
   }
 
@@ -120,11 +121,11 @@ public:
     return m_bHasUserRightsInformation;
   }
 
-  const std::vector<UserRightsImpl>GetUserRightsList() const {
+  const std::vector<UserRightsImpl> GetUserRightsList() const {
     return m_userRightsList;
   }
 
-  const std::vector<UserRolesImpl>GetUserRolesList() const {
+  const std::vector<UserRolesImpl> GetUserRolesList() const {
     return m_userRolesList;
   }
 
@@ -140,7 +141,7 @@ public:
     return m_cipherMode;
   }
 
-  std::shared_ptr<rmscrypto::api::ICryptoProvider>GetCryptoProvider() const {
+  std::shared_ptr<rmscrypto::api::ICryptoProvider> GetCryptoProvider() const {
     return m_pCryptoProvider;
   }
 
@@ -150,7 +151,7 @@ public:
 
 public:
 
-  static std::shared_ptr<ProtectionPolicy>Acquire(
+  static std::shared_ptr<ProtectionPolicy> Acquire(
     const uint8_t                          *pbPublishLicense,
     const size_t                            cbPublishLicense,
     modernapi::IAuthenticationCallbackImpl& authCallback,
@@ -158,7 +159,8 @@ public:
     const bool                              bOffline,
     common::Event                         & hCancelEvent,
     modernapi::ResponseCacheFlags           cacheMask);
-  static std::shared_ptr<ProtectionPolicy>Acquire(
+
+  static std::shared_ptr<ProtectionPolicy> Acquire(
     const uint8_t                          *pbPublishLicense,
     const size_t                            cbPublishLicense,
     modernapi::IAuthenticationCallbackImpl& authCallback,
@@ -167,30 +169,33 @@ public:
     const bool                              bOffline,
     common::Event                         & hCancelEvent,
     modernapi::ResponseCacheFlags           cacheMask);
-  static std::shared_ptr<ProtectionPolicy>Create(
+
+  static std::shared_ptr<ProtectionPolicy> Create(
     const bool                              bPreferDeprecatedAlgorithms,
     const bool                              bAllowAuditedExtraction,
     const std::string                     & templateId,
     modernapi::IAuthenticationCallbackImpl& authenticationCallback,
     const std::string                     & email,
     const modernapi::AppDataHashMap       & signedAppData);
-  static std::shared_ptr<ProtectionPolicy>Create(
+
+  static std::shared_ptr<ProtectionPolicy> Create(
     const bool                              bPreferDeprecatedAlgorithms,
     const bool                              bAllowAuditedExtraction,
     PolicyDescriptorImpl                  & descriptor,
     modernapi::IAuthenticationCallbackImpl& authenticationCallback,
     const std::string                     & email);
-  static std::shared_ptr<ProtectionPolicy>GetCachedProtectionPolicy(
-    const     uint8_t *pbPublishLicense,
-    const  size_t      cbPublishLicense,
-    const std::string  requester = std::string());
+
+  static std::shared_ptr<ProtectionPolicy> GetCachedProtectionPolicy(
+    const uint8_t    *pbPublishLicense,
+    const size_t      cbPublishLicense,
+    const std::string requester = std::string());
 
   ProtectionPolicy();
 
   void Initialize(
-    const uint8_t                                         *pbPublishLicense,
-    size_t                                                 cbPublishLicense,
-    std::shared_ptr<restclients::UsageRestrictionsResponse>response);
+    const uint8_t                                          *pbPublishLicense,
+    size_t                                                  cbPublishLicense,
+    std::shared_ptr<restclients::UsageRestrictionsResponse> response);
 
   void Initialize(restclients::PublishResponse   & response,
                   bool                             bAllowAuditedExtraction,
@@ -200,21 +205,22 @@ public:
                   const modernapi::AppDataHashMap& encryptedData =
                     modernapi::AppDataHashMap());
 
-  void        InitializeValidityTime(
+  void InitializeValidityTime(
     const std::chrono::time_point<std::chrono::system_clock>& ftContentValidUntil);
-  void        InitializeIntervalTime(
+  void InitializeIntervalTime(
     const std::chrono::time_point<std::chrono::system_clock>& ftLicenseValidUntil);
 
-  void        InitializeKey(restclients::KeyDetailsResponse& response);
+  void InitializeKey(restclients::KeyDetailsResponse& response);
 
   static void AddProtectionPolicyToCache(
-    std::shared_ptr<ProtectionPolicy>pProtectionPolicy);
+    std::shared_ptr<ProtectionPolicy> pProtectionPolicy);
 
 private:
 
-  // undefined
+  // undefined copy constructor
   ProtectionPolicy(const ProtectionPolicy&);
 
+  // undefined assignment operator
   ProtectionPolicy& operator=(const ProtectionPolicy&);
 
 private:
@@ -245,7 +251,7 @@ private:
 
 private:
 
-  typedef std::list<std::shared_ptr<ProtectionPolicy> >CachedProtectionPolicies;
+  typedef std::list<std::shared_ptr<ProtectionPolicy>> CachedProtectionPolicies;
 
   static CachedProtectionPolicies *s_pCachedProtectionPolicies;
   static common::Mutex s_cachedProtectionPoliciesMutex;

--- a/sdk/rms_sdk/ModernAPI/PolicyDescriptor.h
+++ b/sdk/rms_sdk/ModernAPI/PolicyDescriptor.h
@@ -6,8 +6,8 @@
  * ======================================================================
  */
 
-#ifndef POLICYDESCRIPTOR_H
-#define POLICYDESCRIPTOR_H
+#ifndef _RMS_LIB_POLICYDESCRIPTOR_H_
+#define _RMS_LIB_POLICYDESCRIPTOR_H_
 
 #include <chrono>
 #include <unordered_map>
@@ -25,6 +25,8 @@ class ProtectionPolicy;
 }
 
 namespace modernapi {
+
+/// @cond internal
 namespace detail {
 struct HashConstString
 {
@@ -36,7 +38,10 @@ struct HashConstString
 template<typename T>
 using HashMapString = std::unordered_map<std::string, T, HashConstString>;
 }
+/// @endcond
+
 using AppDataHashMap = detail::HashMapString<std::string>;
+
 
 /**
  * @brief Specifies users and rights assigned for a file.
@@ -175,4 +180,4 @@ enum OfflineCacheLifetimeConstants {
 } // m_namespace modernapi
 } // m_namespace rmscore
 
-#endif // POLICYDESCRIPTOR_H
+#endif // _RMS_LIB_POLICYDESCRIPTOR_H_

--- a/sdk/rms_sdk/ModernAPI/ProtectedFileStream.h
+++ b/sdk/rms_sdk/ModernAPI/ProtectedFileStream.h
@@ -38,7 +38,11 @@ struct DLL_PUBLIC_RMS GetProtectedFileStreamResult
 };
 
 /*!
-  @brief
+  @brief Wraps a std::iostream to provide transparent encryption and decryption
+  on read and write.
+
+  Use ProtectedFileStream::Acquire when working with encrypted (PFile) content.
+  Use ProtectedFileStream::Create to wrap and encrypt a new stream.
 */
 class DLL_PUBLIC_RMS ProtectedFileStream : public rmscrypto::api::IStream {
 public:
@@ -103,6 +107,18 @@ public:
                                         RESPONSE_CACHE_ONDISK |
                                         RESPONSE_CACHE_CRYPTED));
 
+  /*!
+  @brief Wrap a new stream as a protected stream.
+
+  Creates a new ProtectedFileStream from a UserPolicy object and a backing stream. This method is used to create new PFiles.
+  The PFile is written to the backing stream. The policy used to protect the PFile is defined by the specified
+  UserPolicy object. The resulting ProtectedFileStream can be used to write the actual content of the PFile using APIs from std::io.
+
+  @param policy The UserPolicy object that defines the policy used to protect the created PFile
+  @param stream The backing stream, where encrypted content will be written.
+  @param originalFileExtension The file extension of the original unprotected file.
+  @return A ProtectedFileStream.
+  */
   static std::shared_ptr<ProtectedFileStream> Create(
     std::shared_ptr<UserPolicy>  policy,
     rmscrypto::api::SharedStream stream,
@@ -129,6 +145,7 @@ private:
   std::shared_ptr<UserPolicy> m_policy;
   std::string m_originalFileExtension;
   std::shared_ptr<IStream> m_pImpl;
+
 }; // class ProtectedFileStream
 } // namespace modernapi
 } // namespace rmscore

--- a/sdk/rms_sdk/ModernAPI/UserPolicy.h
+++ b/sdk/rms_sdk/ModernAPI/UserPolicy.h
@@ -16,6 +16,7 @@
 #include "IConsentCallback.h"
 #include "ModernAPIExport.h"
 #include "CacheControl.h"
+#include "TemplateDescriptor.h"
 #include "PolicyDescriptor.h"
 
 namespace rmscore {
@@ -34,46 +35,70 @@ enum GetUserPolicyResultStatus {
 class UserPolicy;
 
 struct DLL_PUBLIC_RMS GetUserPolicyResult {
-  GetUserPolicyResult(GetUserPolicyResultStatus   status,
-                      std::shared_ptr<std::string>referrer,
-                      std::shared_ptr<UserPolicy> policy);
+  GetUserPolicyResult(GetUserPolicyResultStatus    status,
+                      std::shared_ptr<std::string> referrer,
+                      std::shared_ptr<UserPolicy>  policy);
 
-  GetUserPolicyResultStatus   Status;
-  std::shared_ptr<std::string>Referrer;
-  std::shared_ptr<UserPolicy> Policy;
+  GetUserPolicyResultStatus    Status;
+  std::shared_ptr<std::string> Referrer;
+  std::shared_ptr<UserPolicy>  Policy;
 };
 
-/**
+/*!
   @brief Specifies the expected mode for an operation. For example, can library use UI or expect available network.
 */
 enum PolicyAcquisitionOptions {
-  /**
-    @brief The framework will try to perform the operation silently and offline, but will show a UI and connect to a network if necessary.
+  /*!
+  @brief Allow UI and network operations.
+
+  The framework will try to perform the operation silently and offline, but will show a UI and connect to a network if necessary.
   */
   POL_None = 0x0,
 
-  /**
-    The framework will try to perform the operation without connecting to a network. If it needs to connect to a network, the operation will fail. For example, an app can choose not to open a document on the device when it is not connected to a WiFi network unless it can be opened offline.
+  /*!
+  @brief Do not allow UI and network operations.
+
+  The framework will try to perform the operation without connecting to a network. If it needs to connect to a network, the operation will fail. For example, an app can choose not to open a document on the device when it is not connected to a WiFi network unless it can be opened offline.
   */
   POL_OfflineOnly = 0x1
 };
+
+/*!
+@brief Flags related to policy.
+*/
 enum UserPolicyCreationOptions {
   USER_None                   = 0x0,
-  USER_AllowAuditedExtraction = 0x1,     // specifies whether the
-                                         // content can be opened in a non-RMS
-                                         // aware app or not
-  USER_PreferDeprecatedAlgorithms = 0x2, // specifies whether the
-                                         // deprecated algorithms (ECB) is
-                                         // preferred or not
-};
-enum UserPolicyType {
-  TemplateBased = 0, Custom = 1,
+  /*!
+  @brief Content can be opened in a non-RMS-aware app.
+  */
+  USER_AllowAuditedExtraction = 0x1,
+  /*!
+  @brief Deprecated cryptographic algorithms (ECB) are okay. For backwards compatibility.
+  */
+  USER_PreferDeprecatedAlgorithms = 0x2,
 };
 
+/*!
+@brief Source of policy.
+*/
+enum UserPolicyType {
+  /*!
+  @brief Policy was created from a template.
+  */
+  TemplateBased = 0,
+  /*!
+  @brief Policy was created adhoc.
+  */
+  Custom = 1,
+};
+
+/*!
+@brief
+*/
 class DLL_PUBLIC_RMS UserPolicy {
 public:
 
-  static std::shared_ptr<GetUserPolicyResult>Acquire(
+  static std::shared_ptr<GetUserPolicyResult> Acquire(
     const std::vector<unsigned char>& serializedPolicy,
     const std::string               & userId,
     IAuthenticationCallback         & authenticationCallback,
@@ -81,14 +106,14 @@ public:
     PolicyAcquisitionOptions          options,
     ResponseCacheFlags                cacheMask);
 
-  static std::shared_ptr<UserPolicy>CreateFromTemplateDescriptor(
+  static std::shared_ptr<UserPolicy> CreateFromTemplateDescriptor(
     const TemplateDescriptor& templateDescriptor,
     const std::string       & userId,
     IAuthenticationCallback & authenticationCallback,
     UserPolicyCreationOptions options,
     const AppDataHashMap    & signedAppData);
 
-  static std::shared_ptr<UserPolicy>Create(
+  static std::shared_ptr<UserPolicy> Create(
     PolicyDescriptor        & policyDescriptor,
     const std::string       & userId,
     IAuthenticationCallback & authenticationCallback,
@@ -96,31 +121,31 @@ public:
 
   bool AccessCheck(const std::string& right) const;
 
-  UserPolicyType                                    Type();
+  UserPolicyType                                     Type();
 
-  std::string                                       Name();
-  std::string                                       Description();
-  std::shared_ptr<modernapi::TemplateDescriptor>    TemplateDescriptor();
-  std::shared_ptr<modernapi::PolicyDescriptor>      PolicyDescriptor();
-  std::string                                       Owner();
-  std::string                                       IssuedTo();
+  std::string                                        Name();
+  std::string                                        Description();
+  std::shared_ptr<modernapi::TemplateDescriptor>     TemplateDescriptor();
+  std::shared_ptr<modernapi::PolicyDescriptor>       PolicyDescriptor();
+  std::string                                        Owner();
+  std::string                                        IssuedTo();
 
-  bool                                              IsIssuedToOwner();
+  bool                                               IsIssuedToOwner();
 
-  std::string                                       ContentId();
-  const AppDataHashMap                              EncryptedAppData();
-  const AppDataHashMap                              SignedAppData();
-  std::chrono::time_point<std::chrono::system_clock>ContentValidUntil();
+  std::string                                        ContentId();
+  const AppDataHashMap                               EncryptedAppData();
+  const AppDataHashMap                               SignedAppData();
+  std::chrono::time_point<std::chrono::system_clock> ContentValidUntil();
 
-  bool                                              DoesUseDeprecatedAlgorithms();
-  bool                                              IsAuditedExtractAllowed();
+  bool                                               DoesUseDeprecatedAlgorithms();
+  bool                                               IsAuditedExtractAllowed();
 
-  const std::vector<unsigned char>                  SerializedPolicy();
-  std::shared_ptr<core::ProtectionPolicy>           GetImpl();
+  const std::vector<unsigned char>                   SerializedPolicy();
+  std::shared_ptr<core::ProtectionPolicy>            GetImpl();
 
 private:
 
-  UserPolicy(std::shared_ptr<core::ProtectionPolicy>pImpl);
+  UserPolicy(std::shared_ptr<core::ProtectionPolicy> pImpl);
 
   std::shared_ptr<core::ProtectionPolicy> m_pImpl;
   std::shared_ptr<modernapi::TemplateDescriptor> m_templateDescriptor;

--- a/sdk/rmscrypto_sdk/CryptoAPI/CryptoAPI.h
+++ b/sdk/rmscrypto_sdk/CryptoAPI/CryptoAPI.h
@@ -6,8 +6,9 @@
  * ======================================================================
 */
 
-#ifndef _CRYPTO_STREAMS_LIB_API_H_
-#define _CRYPTO_STREAMS_LIB_API_H_
+#ifndef _RMS_CRYPTO_API_H_
+#define _RMS_CRYPTO_API_H_
+
 #include <memory>
 #include <vector>
 #include "CryptoAPIExport.h"
@@ -56,4 +57,4 @@ std::shared_ptr<ICryptoProvider>DLL_PUBLIC_CRYPTO CreateCryptoProvider(
 std::shared_ptr<ICryptoEngine>DLL_PUBLIC_CRYPTO   CreateCryptoEngine();
 } // namespace api
 } // namespace rmscrypto
-#endif // _CRYPTO_STREAMS_LIB_API_H_
+#endif // _RMS_CRYPTO_API_H_

--- a/sdk/rmscrypto_sdk/CryptoAPI/IStream.h
+++ b/sdk/rmscrypto_sdk/CryptoAPI/IStream.h
@@ -6,8 +6,8 @@
  * ======================================================================
  */
 
-#ifndef _CRYPTO_STREAMS_LIB_ISTREAM_H_
-#define _CRYPTO_STREAMS_LIB_ISTREAM_H_
+#ifndef _RMS_CRYPTO_ISTREAM_H_
+#define _RMS_CRYPTO_ISTREAM_H_
 
 #include <future>
 #include <string>
@@ -18,24 +18,35 @@
 namespace rmscrypto {
 namespace api {
 class IStream;
-typedef std::shared_ptr<IStream>SharedStream;
+typedef std::shared_ptr<IStream> SharedStream;
 
+/*!
+@brief Base interface for protected streams.
+
+Ported from [Windows::Storage::Streams::IRandomAccessStream][IRandomAccessStream] and
+[Windows::Storage::Streams::FileRandomAccessStream][FileRandomAccessStream].
+
+[IRandomAccessStream]: https://msdn.microsoft.com/en-us/library/windows/apps/windows.storage.streams.irandomaccessstream.aspx
+[FileRandomAccessStream]: https://msdn.microsoft.com/en-us/library/windows/apps/windows.storage.streams.filerandomaccessstream.aspx
+
+@todo Derive from [std::iostream](http://www.cplusplus.com/reference/istream/iostream/)?
+*/
 class IStream {
 public:
 
   // Async methods. Be sure buffer exists until result will be got from
   // std::future
-  virtual std::shared_future<int64_t>ReadAsync(uint8_t    *pbBuffer,
+  virtual std::shared_future<int64_t> ReadAsync(uint8_t    *pbBuffer,
                                                int64_t     cbBuffer,
                                                int64_t     cbOffset,
                                                std::launch launchType)
     = 0;
-  virtual std::shared_future<int64_t>WriteAsync(const uint8_t *cpbBuffer,
+  virtual std::shared_future<int64_t> WriteAsync(const uint8_t *cpbBuffer,
                                                 int64_t        cbBuffer,
                                                 int64_t        cbOffset,
                                                 std::launch    launchType)
     = 0;
-  virtual std::future<bool>   FlushAsync(std::launch launchType) = 0;
+  virtual std::future<bool> FlushAsync(std::launch launchType) = 0;
 
   // Sync methods
   virtual int64_t             Read(uint8_t *pbBuffer,
@@ -53,7 +64,7 @@ public:
   virtual uint64_t            Size()                     = 0;
   virtual void                Size(uint64_t u64Value)    = 0;
 
-  virtual std::vector<uint8_t>Read(uint64_t u64size)
+  virtual std::vector<uint8_t> Read(uint64_t u64size)
   {
     std::vector<uint8_t> plainText;
 
@@ -70,7 +81,7 @@ public:
 protected:
 
   virtual ~IStream() {}
-};
+}; // class IStream
 } // namespace api
 } // namespace rmscrypto
-#endif // _CRYPTO_STREAMS_LIB_ISTREAM_H_
+#endif // _RMS_CRYPTO_ISTREAM_H_


### PR DESCRIPTION
- Added spaces between return type and method names.
- Cleaned up formatting and typos in a few places.
- Added some more docs.
