### PR TITLE
Issue: When using the sample app, the user selected rights are incorr…

### DIFF
--- a/samples/rms_sample/mainwindow.cpp
+++ b/samples/rms_sample/mainwindow.cpp
@@ -647,7 +647,7 @@ vector<UserRights>MainWindow::openRightsDlg() {
     rmscore::modernapi::RightList rights;
     QString tmpStr;
 
-    for (int col = 0; col < 6; ++col) {
+    for (int col = 0, colMax = model.columnCount(); col < colMax; ++col) {
       QStandardItem *item = model.item(row, col);
 
       if (item == nullptr) continue;
@@ -659,7 +659,9 @@ vector<UserRights>MainWindow::openRightsDlg() {
           users.push_back(tmpStr.toStdString());
         }
       } else {
-        rights.push_back(columnsNames[col].toStdString());
+        if(item->checkState() == Qt::CheckState::Checked) {
+          rights.push_back(columnsNames[col].toStdString());
+        }
       }
     }
 


### PR DESCRIPTION
…ectly applied.

To Reproduce:
1. Use the sample app to protect a file
2. Grant a user VIEW and PRINT rights.
3. After protection, examine the rights granted

Result: the OWNER, VIEW, EDIT, EXPORT, EXTRACT rights were granted.
Expected: the VIEW and PRINT rights should have been granted.

To Fix:  calculate the number of columns instead of using hard-coded value of 6, and check the state of the checkbox before adding the right to the userRights
