### PR TITLE
Use pkg-config to find libsecret.

### DIFF
--- a/sdk/rmscrypto_sdk/Platform/KeyStorage/KeyStorage.pro
+++ b/sdk/rmscrypto_sdk/Platform/KeyStorage/KeyStorage.pro
@@ -35,7 +35,7 @@ win32 {
     SOURCES += KeyStorageWindows.cpp sqlite3.c StorageAccessWindows.cpp
 } unix:!mac {
     CONFIG += link_pkgconfig
-    PKGCONFIG += glib-2.0
+    PKGCONFIG += glib-2.0 libsecret-1
     HEADERS += KeyStoragePosix.h
     SOURCES += KeyStoragePosix.cpp
 } mac {


### PR DESCRIPTION
This allows building with libsecret outside the hardcoded path.